### PR TITLE
Remove unnecessary Documenter dependency.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "4.0.2"
 
 [deps]
 CmdStan = "593b3428-ca2f-500c-ae53-031589ec8ddd"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Mamba = "5424a776-8be3-5c5b-a13f-3551f69ba0e6"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 1.0
 CmdStan
-Documenter
 Mamba

--- a/src/StanMamba.jl
+++ b/src/StanMamba.jl
@@ -1,7 +1,7 @@
 module StanMamba
 
 # package code goes here
-using Mamba, Statistics, Documenter
+using Mamba, Statistics
 
 import CmdStan: convert_a3d
 import Mamba: AbstractChains, Chains
@@ -10,5 +10,5 @@ include("utilities/convert_a3d.jl")
 
 export
   convert_a3d
-  
+
 end # module


### PR DESCRIPTION
Hi, as you may know we are working on a breaking release of Documenter. Therefore, we are putting upperbounds on the packages that have Documenter as a direct dependency (https://github.com/JuliaLang/METADATA.jl/pull/19162) but I noticed that this package have a dependency on Documenter for no reason. This PR removes that.